### PR TITLE
Correct the hostname

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-tn5250.org
+tn5250j.org


### PR DESCRIPTION
#3 broke the website by redirecting the github.io subdomain to an unregistered one. This pr fixes it
