### PR TITLE
optimise table on reference page

### DIFF
--- a/_sass/base/template.scss
+++ b/_sass/base/template.scss
@@ -311,6 +311,18 @@ main
         li {
             margin: 5px 0;
         }
+        
+        thead {
+            text-align: left;
+        }
+        
+        td {
+            vertical-align: top;
+        }
+        
+        #ibm-manuals + table th:first-child  {
+            width : 8em;
+        }
 
         p > code,
         li > code {


### PR DESCRIPTION
left-align table headings, top-align cells and resize first column of IBM Manuals on references page. 

@duncan3dc do I have to regenerate css or does Jekyll do this for me?

Feel free to suggest better options or things that I missed.
