### PR TITLE
Apply some default styling to tables

### DIFF
--- a/_sass/base/template.scss
+++ b/_sass/base/template.scss
@@ -312,6 +312,12 @@ main
             margin: 5px 0;
         }
 
+        td, th {
+            vertical-align: top;
+            text-align: left;
+            padding-right: 16px;
+        }
+
         p > code,
         li > code {
             display: inline-block;


### PR DESCRIPTION
- Table headers use center alignment by default, so override this to default to left (`text-align`)
- Table cells use central vertical alignment by default, but top alignment is a more sensible default (`vertical-align`)
- Tables with columns that display very close together without borders can make the contents hard to separate, ensure there's some space at the end of each table cell (`padding-left`)
