### PR TITLE
Switch to ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.2
+  - 2.4
 
 install:
   - gem install jekyll

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.1
+  - 2.2
 
 install:
   - gem install jekyll


### PR DESCRIPTION
travis will not install jekyll under ruby 2.1, so we should be able to switch to 2.2?